### PR TITLE
improve port discovery of flutter server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
             adb logcat -t 1000 | grep "flutter"
       #        appium server -pa=/wd/hub & wait-on http://127.0.0.1:4723/wd/hub/status &&
       - name: upload appium logs
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: appium-logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,6 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: run tests
-        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -101,7 +100,7 @@ jobs:
             adb logcat -t 1000 | grep "flutter"
       #        appium server -pa=/wd/hub & wait-on http://127.0.0.1:4723/wd/hub/status &&
       - name: upload appium logs
-        continue-on-error: true
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: appium-logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           dart pub global activate rps --version 0.8.0
           flutter build apk --debug
           cd android && ./gradlew app:assembleDebug -Ptarget=`pwd`/../integration_test/appium.dart
-      - name: "List files"
+      - name: 'List files'
         continue-on-error: true
         run: |
           ls -l ${{ github.workspace }}/server/demo-app/build/app/outputs/apk/debug/
@@ -48,54 +48,57 @@ jobs:
           name: Android-build
           path: ${{ github.workspace }}/server/demo-app/build/app/outputs/apk/debug/app-debug.apk
   Run_Tests:
-   needs: Build_Server
-   runs-on: ubuntu-latest
-   strategy:
-     matrix:
-        api-level: [ 29 ]
-        target: [ google_apis ]
-   steps:
-   - uses: actions/checkout@v2
-   - uses: actions/setup-node@v4
-     with:
-      node-version: 20
-   - name: Set up JDK 17
-     uses: actions/setup-java@v3
-     with:
-      java-version: '17'
-      distribution: 'adopt'
-   - uses: dawidd6/action-download-artifact@v3
-     with:
-       name: Android-build
-   - name: Display structure of downloaded files
-     run: ls -R
-   - uses: subosito/flutter-action@v2
-     with:
-       flutter-version: 3.19.6
-       channel: 'stable'
-   - name: Enable KVM group perms
-     run: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
-   - name: run tests
-     uses: reactivecircus/android-emulator-runner@v2
-     with:
-       api-level: ${{ matrix.api-level }}
-       target: ${{ matrix.target }}
-       arch: x86_64
-       profile: Nexus 6
-       script: |
-         adb devices
-         node --version
-         npm install -g wait-on
-         npm install -g appium
-         appium driver install uiautomator2
-         npm install
-         npm run build
-         appium driver list
-         npm run wdio-android
-#        appium server -pa=/wd/hub & wait-on http://127.0.0.1:4723/wd/hub/status &&
-         
-
-
+    needs: Build_Server
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [29]
+        target: [google_apis]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - uses: dawidd6/action-download-artifact@v3
+        with:
+          name: Android-build
+      - name: Display structure of downloaded files
+        run: ls -R
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.19.6
+          channel: 'stable'
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            adb devices
+            node --version
+            npm install -g wait-on
+            npm install -g appium
+            appium driver install uiautomator2
+            npm install
+            npm run build
+            appium driver list
+            npm run wdio-android
+            adb logcat -t 1000 | grep "flutter"
+      #        appium server -pa=/wd/hub & wait-on http://127.0.0.1:4723/wd/hub/status &&
+      - name: upload appium logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: appium-logs
+          path: ${{ github.workspace }}/appium-logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: run tests
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -94,6 +95,8 @@ jobs:
             npm install
             npm run build
             appium driver list
+            mkdir ${{ github.workspace }}/appium-logs
+            adb logcat > ${{ github.workspace }}/appium-logs/flutter.txt &
             npm run wdio-android
             adb logcat -t 1000 | grep "flutter"
       #        appium server -pa=/wd/hub & wait-on http://127.0.0.1:4723/wd/hub/status &&

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dist
 .pnp.*
 .history
 .npmrc
+appium-logs

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -23,12 +23,15 @@ import {
   ELEMENT_CACHE,
 } from './commands/element';
 
-import { isFlutterDriverCommand } from './utils';
+import {
+  fetchFlutterServerPort,
+  getFreePort,
+  isFlutterDriverCommand,
+} from './utils';
 import { W3C_WEB_ELEMENT_IDENTIFIER } from '@appium/support/build/lib/util';
-import { sleep, waitForCondition } from 'asyncbox';
-import { log } from './logger';
-
-const DEFAULT_FLUTTER_SERVER_PORT = 8888;
+import { androidPortForward, androidRemovePortForward } from './android';
+import { iosPortForward, iosRemovePortForward } from './iOS';
+import { sleep } from 'asyncbox';
 
 export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
   // @ts-ignore
@@ -60,7 +63,7 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
       'class name',
       'semantics label',
       'text',
-      'type'
+      'type',
     ];
   }
 
@@ -152,7 +155,7 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
       'POST',
       {
         origin,
-        offset
+        offset,
       },
     );
   }
@@ -221,34 +224,53 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
       ...JSON.parse(JSON.stringify(args)),
     );
 
-    // HACK for eliminatin socket hang up by waiting 1 sec
     await sleep(1000);
-    // @ts-ignore
-    console.log('PageSource', await this.proxydriver.getPageSource());
+    const { appPackage, bundleId } = this.proxydriver.opts as any;
+    const packageName = appPackage || bundleId;
+    const callbacks =
+      this.proxydriver instanceof AndroidUiautomator2Driver
+        ? {
+            portForwardCallback: androidPortForward,
+            portReleaseCallback: androidRemovePortForward,
+          }
+        : this.proxydriver.isRealDevice()
+          ? {
+              portForwardCallback: iosPortForward,
+              portReleaseCallback: iosRemovePortForward,
+            }
+          : {};
+    const systemPort =
+      this.proxydriver instanceof XCUITestDriver &&
+      !this.proxydriver.isRealDevice()
+        ? null
+        : await getFreePort();
+
+    const udid =
+      this.proxydriver instanceof AndroidUiautomator2Driver
+        ? this.proxydriver.opts.udid!
+        : (this.proxydriver as XCUITestDriver).opts.udid!;
+
+    //Extract the bundle Id
+    const flutterPort = await fetchFlutterServerPort({
+      udid,
+      packageName,
+      ...callbacks,
+      systemPort,
+    });
+
+    if (flutterPort == null) {
+      throw new Error(
+        `Flutter server is not started. ` +
+          `Please make sure the application under test is configured properly according to ` +
+          `https://github.com/AppiumTestDistribution/appium-flutter-server and that it does not crash on startup.`,
+      );
+    }
+
     // @ts-ignore
     this.proxy = new JWProxy({
       server: '127.0.0.1',
-      port: this.flutterPort,
+      port: flutterPort,
     });
-    try {
-      await waitForCondition(async () => {
-        try {
-          // @ts-ignore
-          await this.proxy.command('/status', 'GET');
-          return true;
-        } catch(err: any) {
-          log.info('FlutterServer not reachable, Trying..', err);
-          return false;
-        }
-      }, {
-        waitMs: 15000,
-        intervalMs: 1000,
-      })
-    } catch(err: any) {
-      log.error('FlutterServer not reachable', err);
-      throw new Error(err);
-    }
-
 
     await this.proxy.command('/session', 'POST', { capabilities: caps });
     return sessionCreated;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -245,12 +245,8 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
         ? null
         : await getFreePort();
 
-    const udid =
-      this.proxydriver instanceof AndroidUiautomator2Driver
-        ? this.proxydriver.opts.udid!
-        : (this.proxydriver as XCUITestDriver).opts.udid!;
+    const udid = this.proxydriver.opts.udid!;
 
-    //Extract the bundle Id
     const flutterPort = await fetchFlutterServerPort({
       udid,
       packageName,

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -223,9 +223,6 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
       caps,
       ...JSON.parse(JSON.stringify(args)),
     );
-
-    await sleep(1000);
-
     const packageName =
       this.proxydriver instanceof AndroidUiautomator2Driver
         ? this.proxydriver.opts.appPackage!

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -252,14 +252,14 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
 
     const udid = this.proxydriver.opts.udid!;
 
-    const flutterPort = await fetchFlutterServerPort({
+    this.flutterPort = await fetchFlutterServerPort({
       udid,
       packageName,
       ...portcallbacks,
       systemPort,
     });
 
-    if (!flutterPort) {
+    if (!this.flutterPort) {
       throw new Error(
         `Flutter server is not started. ` +
           `Please make sure the application under test is configured properly according to ` +
@@ -270,7 +270,7 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
     // @ts-ignore
     this.proxy = new JWProxy({
       server: '127.0.0.1',
-      port: flutterPort,
+      port: this.flutterPort,
     });
 
     await this.proxy.command('/session', 'POST', { capabilities: caps });
@@ -282,7 +282,10 @@ export class AppiumFlutterDriver extends BaseDriver<FlutterDriverConstraints> {
   }
 
   async deleteSession() {
-    if (this.proxydriver instanceof AndroidUiautomator2Driver) {
+    if (
+      this.proxydriver instanceof AndroidUiautomator2Driver &&
+      this.flutterPort
+    ) {
       // @ts-ignore
       await this.proxydriver.adb.removePortForward(this.flutterPort);
     }

--- a/src/iOS.ts
+++ b/src/iOS.ts
@@ -4,8 +4,6 @@ import XCUITestDriver from 'appium-xcuitest-driver';
 import type { InitialOpts } from '@appium/types';
 import { log } from './logger';
 import { DEVICE_CONNECTIONS_FACTORY } from './iProxy';
-import { sleep } from 'asyncbox';
-import { fetchFlutterServerPort, getFreePort } from './utils';
 
 const setupNewIOSDriver = async (...args: any[]): Promise<XCUITestDriver> => {
   const iosdriver = new XCUITestDriver({} as InitialOpts);
@@ -13,14 +11,22 @@ const setupNewIOSDriver = async (...args: any[]): Promise<XCUITestDriver> => {
   return iosdriver;
 };
 
-const portForward = async (
+export const startIOSSession = async (
+  flutterDriver: AppiumFlutterDriver,
+  caps: Record<string, any>,
+  ...args: any[]
+): Promise<XCUITestDriver> => {
+  log.info(`Starting an IOS proxy session`);
+  const iOSDriver = await setupNewIOSDriver(...args);
+  log.info('iOS session started', iOSDriver);
+  return iOSDriver;
+};
+
+export async function iosPortForward(
   udid: string,
   systemPort: number,
-  devicePort: any,
-) => {
-  if (!systemPort) {
-    systemPort = await getFreePort();
-  }
+  devicePort: number,
+) {
   log.info(
     `Forwarding port ${systemPort} to device port ${devicePort} ${udid}`,
   );
@@ -28,29 +34,8 @@ const portForward = async (
     usePortForwarding: true,
     devicePort: devicePort,
   });
-  return systemPort;
-};
+}
 
-export const startIOSSession = async (
-  flutterDriver: AppiumFlutterDriver,
-  caps: Record<string, any>,
-  ...args: any[]
-): Promise<[XCUITestDriver, number]> => {
-  log.info(`Starting an IOS proxy session`);
-  const iOSDriver = await setupNewIOSDriver(...args);
-  log.info('Looking for port Flutter server is listening too...');
-  await sleep(2000);
-  const flutterServerPort = fetchFlutterServerPort(iOSDriver.logs.syslog.logs);
-  if (iOSDriver.isRealDevice()) {
-    caps.flutterServerPort = await portForward(
-      iOSDriver.udid,
-      caps.flutterServerPort,
-      flutterServerPort,
-    );
-  } else {
-    //incase of emulator use the same port where the flutter server is running
-    caps.flutterServerPort = flutterServerPort;
-  }
-  log.info('iOS session started', iOSDriver);
-  return [iOSDriver, caps.flutterServerPort];
-};
+export function iosRemovePortForward(udid: string, systemPort: number) {
+  DEVICE_CONNECTIONS_FACTORY.releaseConnection(udid, systemPort);
+}

--- a/src/iProxy.ts
+++ b/src/iProxy.ts
@@ -125,7 +125,7 @@ class DeviceConnectionsFactory {
     return `${SPLITTER}${util.hasValue(port) ? port : ''}`;
   }
 
-  _toKey(udid = null, port = null) {
+  _toKey(udid: string, port: number) {
     return `${util.hasValue(udid) ? udid : ''}${SPLITTER}${util.hasValue(port) ? port : ''}`;
   }
 
@@ -144,7 +144,7 @@ class DeviceConnectionsFactory {
     return keys;
   }
 
-  listConnections(udid = null, port = null, strict = false) {
+  listConnections(udid: string | null, port: number, strict = false) {
     if (!udid && !port) {
       return [];
     }
@@ -259,7 +259,7 @@ class DeviceConnectionsFactory {
     log.info(`Successfully requested the connection for ${currentKey}`);
   }
 
-  releaseConnection(udid = null, port = null) {
+  releaseConnection(udid: string, port: number) {
     if (!udid && !port) {
       log.warn(
         'Neither device UDID nor local port is set. ' +

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,22 +12,14 @@ export const createSession: any = async function (
   try {
     switch (_.toLower(caps.platformName)) {
       case PLATFORM.IOS:
-        [this.proxydriver, this.flutterPort] = await startIOSSession(
-          this,
-          caps,
-          ...args,
-        );
+        this.proxydriver = await startIOSSession(this, caps, ...args);
         this.proxydriver.relaxedSecurityEnabled = this.relaxedSecurityEnabled;
         this.proxydriver.denyInsecure = this.denyInsecure;
         this.proxydriver.allowInsecure = this.allowInsecure;
 
         break;
       case PLATFORM.ANDROID:
-        [this.proxydriver, this.flutterPort] = await startAndroidSession(
-          this,
-          caps,
-          ...args,
-        );
+        this.proxydriver = await startAndroidSession(this, caps, ...args);
         this.proxydriver.relaxedSecurityEnabled = this.relaxedSecurityEnabled;
         this.proxydriver.denyInsecure = this.denyInsecure;
         this.proxydriver.allowInsecure = this.allowInsecure;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,8 +108,8 @@ export async function fetchFlutterServerPort({
   const isSimulator = !systemPort;
   while (startPort <= endPort) {
     /**
-     * For ios simulators, we dont need a dedicayed system port and no port forwarding is required
-     * We need to same port range used by flutter server to check if the server is running
+     * For ios simulators, we dont need a dedicated system port and no port forwarding is required
+     * We need to use the same port range used by flutter server to check if the server is running
      */
     if (isSimulator) {
       systemPort = startPort;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,8 +128,8 @@ export async function fetchFlutterServerPort({
       if (portReleaseCallback) {
         await portReleaseCallback(udid, systemPort!);
       }
-      devicePort++;
     }
+    devicePort++;
   }
   return null;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import { waitForCondition } from 'asyncbox';
 import { JWProxy } from '@appium/base-driver';
 
 const DEVICE_PORT_RANGE = [9000, 9020];
-const SYSTEM_PORT_RANGE = [11000, 11100];
+const SYSTEM_PORT_RANGE = [10000, 11000];
 
 export async function getProxyDriver(
   strategy: string,

--- a/test/specs/sample.e2e.js
+++ b/test/specs/sample.e2e.js
@@ -1,0 +1,19 @@
+import { browser, expect } from '@wdio/globals';
+
+async function performLogin(userName = 'admin', password = '1234') {
+  await browser.takeScreenshot();
+  await browser.flutterBySemanticsLabel$('username_text_field').clearValue();
+  await browser
+    .flutterBySemanticsLabel$('username_text_field')
+    .addValue(userName);
+
+  await browser.flutterBySemanticsLabel$('password_text_field').clearValue();
+  await browser.flutterByValueKey$('password').addValue(password);
+  await browser.flutterBySemanticsLabel$('login_button').click();
+}
+
+describe('My Login application', () => {
+  it('Create Session with Flutter Integration Driver', async () => {
+    await performLogin();
+  });
+});

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -111,7 +111,7 @@ export const config: Options.Testrunner = {
   // connectionRetryTimeout: 120000,
   //
   // Default request retries count
-  // connectionRetryCount: 3,
+  connectionRetryCount: 0,
   //
   // Test runner services
   // Services take over a specific job you don't want to take care of. They enhance

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,7 +1,12 @@
 // @ts-ignore
 import type { Options } from '@wdio/types';
 import { join } from 'node:path';
-const appiumServerPath = join(process.cwd(), 'node_modules', 'appium', 'index.js');
+const appiumServerPath = join(
+  process.cwd(),
+  'node_modules',
+  'appium',
+  'index.js',
+);
 console.log(appiumServerPath);
 export const config: Options.Testrunner = {
   //
@@ -112,12 +117,19 @@ export const config: Options.Testrunner = {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  services: [['flutter-by', {}], ['appium', {
-    args: {
-      basePath: '/wd/hub',
-      port: 4723,
-    }
-  }]],
+  services: [
+    ['flutter-by', {}],
+    [
+      'appium',
+      {
+        args: {
+          basePath: '/wd/hub',
+          port: 4723,
+          logPath: './appium-logs',
+        },
+      },
+    ],
+  ],
   //
   // Framework you want to run your specs with.
   // The following are supported: Mocha, Jasmine, and Cucumber

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -41,7 +41,7 @@ export const config: Options.Testrunner = {
   // The path of the spec files will be resolved relative from the directory of
   // of the config file unless it's absolute.
   //
-  specs: ['./test/specs/**/*.js'],
+  specs: ['./test/specs/**/sample*.js'],
   // Patterns to exclude.
   exclude: [
     // 'path/to/excluded/files'

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -125,7 +125,7 @@ export const config: Options.Testrunner = {
         args: {
           basePath: '/wd/hub',
           port: 4723,
-          logPath: './appium-logs',
+          logPath: join(process.cwd(), 'appium-logs'),
         },
       },
     ],

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -8,6 +8,7 @@ const appiumServerPath = join(
   'index.js',
 );
 console.log(appiumServerPath);
+console.log(join(process.cwd(), 'appium-log.txt'));
 export const config: Options.Testrunner = {
   //
   // ====================
@@ -25,7 +26,6 @@ export const config: Options.Testrunner = {
       transpileOnly: true,
     },
   },
-
   //
   // ==================
   // Specify Test Files
@@ -125,7 +125,7 @@ export const config: Options.Testrunner = {
         args: {
           basePath: '/wd/hub',
           port: 4723,
-          logPath: join(process.cwd(), 'appium-logs'),
+          log: join(process.cwd(), 'appium-logs', 'logs.txt'),
         },
       },
     ],


### PR DESCRIPTION
**Approach taken:**

1. start port forward to device port 9000
2. check if there is a response. If there is no response and the port is closed then try again on the same port until the timeout (e.g. the device server has not started yet)
3. if there is a response then check if it matches to the destination serveer (e.g. app id is the same)
4. if yes then proceed with this port
5. if there is a response but from another app (w.g. wrong format or wrong app id) then remove the port forward, increase the device port number ( e.g. 9001, 9002, ... ) and try again from the first step