### PR TITLE
fix: Respect adb settings provided to the driver

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -23,20 +23,16 @@ export const startAndroidSession = async (
 };
 
 export async function androidPortForward(
-  udid: string,
+  adb: ADB,
   systemPort: number,
   devicePort: number,
 ) {
-  let adb = new ADB();
-  if (udid) adb.setDeviceId(udid);
   await adb.forwardPort(systemPort!, devicePort);
 }
 
 export async function androidRemovePortForward(
-  udid: string,
+  adb: ADB,
   systemPort: number,
 ) {
-  let adb = new ADB();
-  if (udid) adb.setDeviceId(udid);
   await adb.removePortForward(systemPort);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+export type PortForwardCallback = (udid: string, systemPort: number, devicePort: number) => any;
+export type PortReleaseCallback = (udid: string, systemPort: number) => any;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { waitForCondition } from 'asyncbox';
 import { JWProxy } from '@appium/base-driver';
 import { desiredCapConstraints } from './desiredCaps';
 import { DriverCaps } from '@appium/types';
+import type { PortForwardCallback, PortReleaseCallback } from './types';
 
 const DEVICE_PORT_RANGE = [9000, 9020];
 const SYSTEM_PORT_RANGE = [10000, 11000];
@@ -99,12 +100,8 @@ export async function fetchFlutterServerPort({
 }: {
   udid: string;
   systemPort?: number | null;
-  portForwardCallback?: (
-    udid: string,
-    systemPort: number,
-    devicePort: number,
-  ) => any;
-  portReleaseCallback?: (udid: string, systemPort: number) => any;
+  portForwardCallback?: PortForwardCallback;
+  portReleaseCallback?: PortReleaseCallback;
   packageName: string;
   flutterCaps: DriverCaps<FlutterDriverConstraints>;
 }): Promise<number | null> {


### PR DESCRIPTION
Crating a new adb instance means all settings it gets from UIA2 driver are lost. This should not happen, so we must reuse the same adb instance the driver has.