### PR TITLE
chore: Reduce the appium peer dependency to 2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-flutter-integration-driver",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-flutter-integration-driver",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT License",
       "dependencies": {
         "@appium/base-driver": "^9.6.0",
@@ -57,7 +57,7 @@
         "webdriverio": "^8.38.0"
       },
       "peerDependencies": {
-        "appium": "^2.10.3"
+        "appium": "^2.5.4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webdriverio": "^8.38.0"
   },
   "peerDependencies": {
-    "appium": "^2.10.3"
+    "appium": "^2.5.4"
   },
   "dependencies": {
     "@appium/base-driver": "^9.6.0",


### PR DESCRIPTION
Driver fails to install unless the users are having the latest appium server 

```
 appium driver install --source npm appium-flutter-integration-driver
✖ Checking if 'appium-flutter-integration-driver' is compatible
Error: ✖ 'appium-flutter-integration-driver' cannot be installed because the server version it requires (^2.10.3) does not meet the currently installed one (2.5.4). Please install a compatible server version first.
```

Reducing to the highest download in the recent release
