### PR TITLE
feat: enable webview context handling and command proxying in driver

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -125,7 +125,8 @@ export const config: Options.Testrunner = {
         args: {
           basePath: '/wd/hub',
           port: 4723,
-          log: join(process.cwd(), 'appium-logs', 'logs.txt')
+          log: join(process.cwd(), 'appium-logs', 'logs.txt'),
+          allowInsecure: 'chromedriver_autodownload',
         },
       },
     ],


### PR DESCRIPTION
This PR improves webview context switching by ensuring `proxyWebViewActive` is set correctly. This enables UIA2 to properly proxy webview commands to ChromeDriver on Android, while allowing XCUITest to handle both webview and native commands on iOS.

It also adds an “avoid proxy” list (referenced from the Appium Flutter Driver repo) to better handle specific commands when in a webview context.

The changes have been tested thoroughly with Flutter, native, and webview contexts — including multiple context switches on both iOS and Android — with no issues observed.

This addresses the issue here: https://github.com/AppiumTestDistribution/appium-flutter-integration-driver/issues/118